### PR TITLE
Adding missing Azure heading and fixed broken links for events pointi…

### DIFF
--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -87,7 +87,6 @@ resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
    provider_name = "AWS"
 }
 
-
 resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
    project_id =  mongodbatlas_cloud_provider_access_setup.setup_only.project_id
    role_id    =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
@@ -99,6 +98,7 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
 
 ```
 
+## Example Usage with Azure
 
 ```terraform
 

--- a/docs/resources/event_trigger.md
+++ b/docs/resources/event_trigger.md
@@ -104,10 +104,10 @@ resource "mongodbatlas_event_trigger" "test" {
 * `function_id` - (Optional) The ID of the function associated with the trigger.
 * `disabled` - (Optional) Default: `false` If `true`, the trigger is disabled.
 
-* `config_operation_type` - Required for `AUTHENTICATION` type. The [authentication operation type](https://docs.mongodb.com/realm/triggers/authentication-triggers/#std-label-authentication-event-operation-types) to listen for. Possible Values: `LOGIN`, `CREATE`, `DELETE`
-* `config_providers` - Required for `AUTHENTICATION` type. A list of one or more [authentication provider](https://docs.mongodb.com/realm/authentication/providers/) id values. The trigger will only listen for authentication events produced by these providers.
+* `config_operation_type` - Required for `AUTHENTICATION` type. The [authentication operation type](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/#std-label-atlas-triggers) to listen for. Possible Values: `LOGIN`, `CREATE`, `DELETE`
+* `config_providers` - Required for `AUTHENTICATION` type. A list of one or more [authentication provider](https://www.mongodb.com/docs/atlas/app-services/authentication/#authentication-providers-1) id values. The trigger will only listen for authentication events produced by these providers.
 
-* `config_operation_types` - Required for `DATABASE` type. The [database event operation types](https://docs.mongodb.com/realm/triggers/database-triggers/#std-label-database-events) to listen for. This must contain at least one value. Possible Values: `INSERT`, `UPDATE`, `REPLACE`, `DELETE`
+* `config_operation_types` - Required for `DATABASE` type. The [database event operation types](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/database-triggers/#std-label-atlas-database-event-operation-types) to listen for. This must contain at least one value. Possible Values: `INSERT`, `UPDATE`, `REPLACE`, `DELETE`
 * `config_database` - Required for `DATABASE` type. The name of the MongoDB database to watch.
 * `config_collection` - Optional for `DATABASE` type. The name of the MongoDB collection that the trigger watches for change events. The collection must be part of the specified database.
 * `config_service_id` - Required for `DATABASE` type. The ID of the MongoDB Service associated with the trigger.
@@ -116,9 +116,9 @@ resource "mongodbatlas_event_trigger" "test" {
 * `config_full_document` - Optional for `DATABASE` type. If true, indicates that `UPDATE` change events should include the most current [majority-committed](https://docs.mongodb.com/manual/reference/read-concern-majority/) version of the modified document in the fullDocument field.
 * `unordered` - Only Available for Database Triggers. If true, event ordering is disabled and this trigger can process events in parallel. If false, event ordering is enabled and the trigger executes serially.
 
-* `config_schedule` - Required for `SCHEDULED` type. A [cron expression](https://docs.mongodb.com/realm/triggers/cron-expressions/) that defines the trigger schedule.
+* `config_schedule` - Required for `SCHEDULED` type. A [cron expression](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/scheduled-triggers/#cron-expressions) that defines the trigger schedule.
 
-* `event_processors` - (Optional) An object where each field name is an event processor ID and each value is an object that configures its corresponding event processor. The following event processors are supported: `AWS_EVENTBRIDGE` For an example configuration object, see [Send Trigger Events to AWS EventBridge](https://docs.mongodb.com/realm/triggers/eventbridge/#std-label-event_processor_example).
+* `event_processors` - (Optional) An object where each field name is an event processor ID and each value is an object that configures its corresponding event processor. The following event processors are supported: `AWS_EVENTBRIDGE` For an example configuration object, see [Send Trigger Events to AWS EventBridge](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/aws-eventbridge/#send-trigger-events-to-aws-eventbridge).
 * `event_processors.0.aws_eventbridge.config_account_id` - (Optional) AWS Account ID.
 * `event_processors.0.aws_eventbridge.config_region` - (Optional) Region of AWS Account.
 

--- a/docs/resources/event_trigger.md
+++ b/docs/resources/event_trigger.md
@@ -129,6 +129,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Terraform's unique identifier used internally for state management.
 * `trigger_id` - The unique ID of the trigger.
 * `function_name` - The name of the function associated with the trigger.
+
 ## Import
 
 Event trigger can be imported using project ID, App ID and Trigger ID, in the format `project_id`--`app_id`-`trigger_id`, e.g.

--- a/docs/resources/event_trigger.md
+++ b/docs/resources/event_trigger.md
@@ -104,7 +104,7 @@ resource "mongodbatlas_event_trigger" "test" {
 * `function_id` - (Optional) The ID of the function associated with the trigger.
 * `disabled` - (Optional) Default: `false` If `true`, the trigger is disabled.
 
-* `config_operation_type` - Required for `AUTHENTICATION` type. The [authentication operation type](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/#std-label-atlas-triggers) to listen for. Possible Values: `LOGIN`, `CREATE`, `DELETE`
+* `config_operation_type` - Required for `AUTHENTICATION` type. The [authentication operation type](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/authentication-triggers/#authentication-events) to listen for. Possible Values: `LOGIN`, `CREATE`, `DELETE`
 * `config_providers` - Required for `AUTHENTICATION` type. A list of one or more [authentication provider](https://www.mongodb.com/docs/atlas/app-services/authentication/#authentication-providers-1) id values. The trigger will only listen for authentication events produced by these providers.
 
 * `config_operation_types` - Required for `DATABASE` type. The [database event operation types](https://www.mongodb.com/docs/atlas/atlas-ui/triggers/database-triggers/#std-label-atlas-database-event-operation-types) to listen for. This must contain at least one value. Possible Values: `INSERT`, `UPDATE`, `REPLACE`, `DELETE`
@@ -129,7 +129,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Terraform's unique identifier used internally for state management.
 * `trigger_id` - The unique ID of the trigger.
 * `function_name` - The name of the function associated with the trigger.
-
 ## Import
 
 Event trigger can be imported using project ID, App ID and Trigger ID, in the format `project_id`--`app_id`-`trigger_id`, e.g.


### PR DESCRIPTION
## Description

Added a missing CSP heading and 
https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access#example-usage-with-aws-1

Fixed broken Realm links in event_bridge
https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/event_trigger
